### PR TITLE
Add .meteor and smart.lock to the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .build*
+.meteor
+smart.lock


### PR DESCRIPTION
Those files are added when calling `mrt test-packages ./`
