### PR TITLE
Fix for documents with prototype.

### DIFF
--- a/collection2.js
+++ b/collection2.js
@@ -392,7 +392,12 @@ function doValidate(type, args, skipAutoValue, userId, isFromTrustedCode) {
   // will allow these fields to be considered for validation by adding them
   // to the $set in the modifier. This is no doubt prone to errors, but there
   // probably isn't any better way right now.
-  var docToValidate = _.clone(doc);
+  var docToValidate = {};
+  for (var prop in doc) {
+    if (doc.hasOwnProperty(prop)) {
+      docToValidate[prop] = doc[prop];
+    }
+  }
   if (Meteor.isServer && isUpsert && _.isObject(selector)) {
     var set = docToValidate.$set || {};
     docToValidate.$set = _.clone(selector);


### PR DESCRIPTION
I think I discover bug while using collection2 with documents that was changed by transform function.

This is copy-paste form meteor docs with use case I am talking about:

```
// An Animal class that takes a document in its constructor
Animal = function (doc) {
  _.extend(this, doc);
};
_.extend(Animal.prototype, {
  makeNoise: function () {
    console.log(this.sound);
  }
});

// Define a Collection that uses Animal as its document
Animals = new Meteor.Collection("Animals", {
  transform: function (doc) { return new Animal(doc); }
});

// Create an Animal and call its makeNoise method
Animals.insert({name: "raptor", sound: "roar"});
Animals.findOne({name: "raptor"}).makeNoise(); // prints "roar"
```

This use case probably was not planned to be supported when building this package but when my transform function change object from plain js object to object with prototype I got this error on insert:

```
Exception while invoking method '/UniContentTest/insert' TypeError: Cannot call method 'depend' of undefined
at SimpleSchemaValidationContext.keyErrorMessage (packages/simple-schema/simple-schema-context.js:169)
at getErrorObject (packages/collection2/collection2.js:460)
at doValidate (packages/collection2/collection2.js:447)
at self.deny.insert (packages/collection2/collection2.js:214)
```

And it seems to be caused by underscore _.clone() that clone object to one "level" copy with all prototype properties from original object. This happened after cleaning function so this additional fields goes to function that does validation and make it fail in unexpected way.

 I don't really know what magic happens in simple-schema part and most likely there is some better way to do this but instead of using underscore clone i use simple loop for this part and it seems to fix my problem.
