### PR TITLE
Added attachBaseSchema() method to allow adding multiple schemas to a collection

### DIFF
--- a/collection2.js
+++ b/collection2.js
@@ -76,13 +76,13 @@ var parseSimpleSchema = function(ss) {
 }
 
 Meteor.Collection.prototype.attachBaseSchema = function(ss) {
-	
+
 	var self = this;
 
 	ss = parseSimpleSchema(ss);
 	self.baseSchema = self.baseSchema || {};
 	self.baseSchema = _.extend(self.baseSchema, ss);
-		
+
 }
 
 Meteor.Collection.prototype.attachSchema = function c2AttachSchema(ss) {
@@ -98,7 +98,7 @@ Meteor.Collection.prototype.attachSchema = function c2AttachSchema(ss) {
   // Loop over fields definitions and ensure collection indexes (server side only)
   _.each(ss.schema(), function(definition, fieldName) {
     if (Meteor.isServer && ('index' in definition || definition.unique === true)) {
-      
+
       function setUpIndex() {
         var index = {}, indexValue;
         // If they specified `unique: true` but not `index`, we assume `index: 1` to set up the unique index in mongo
@@ -131,7 +131,7 @@ Meteor.Collection.prototype.attachSchema = function c2AttachSchema(ss) {
           }
         }
       }
-      
+
       if (hasStartedUp) {
         setUpIndex();
       } else {
@@ -273,6 +273,18 @@ Meteor.Collection.prototype.attachSchema = function c2AttachSchema(ss) {
   // additional deny functions, but does not have to.
 };
 
+Meteor.Collection.prototype.extendSchema = function c2ExtendSchema(newSchema) {
+
+  if (newSchema instanceof SimpleSchema) { newSchema = newSchema.schema(); }
+  if (!_.isObject(newSchema)) { newSchema = {}; }
+
+  var self = this,
+      oldSchema = self._c2 && self._c2._simpleSchema ? self._c2._simpleSchema.schema() : {},
+      extSchema = _.extend(oldSchema, newSchema);
+  self.attachSchema(extSchema);
+
+}
+
 Meteor.Collection.prototype.simpleSchema = function c2SS() {
   var self = this;
   return self._c2 ? self._c2._simpleSchema : null;
@@ -399,7 +411,7 @@ function doValidate(type, args, skipAutoValue, userId, isFromTrustedCode) {
       }
     });
   }
-  
+
   // Preliminary cleaning on both client and server. On the server, automatic
   // values will also be set at this point.
   doClean(doc, (Meteor.isServer && !skipAutoValue), true, true, options.removeEmptyStrings !== false);


### PR DESCRIPTION
This method allows you to attach "base schemas" to a collection before calling attachSchema() to attach its specific schema.

A typical use case is to attach a standard schema for timestamped documents (with createdAt, updatedAt, etc. fields).
