### PR TITLE
Version bump simple-schema dependecy

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.on_use(function(api) {
 
   if (api.versionsFrom) {
-    api.use(['aldeed:simple-schema@1.0.1']);
+    api.use(['aldeed:simple-schema@1.0.3']);
     api.imply(['aldeed:simple-schema']);
 
     api.use('underscore@1.0.0');


### PR DESCRIPTION
Update simple-schema to 1.0.3 because of aldeed/meteor-simple-schema#144 and aldeed/meteor-simple-schema#145.
Collection2 is affected when used with Meteor.users which should use blackbox on services.
