### PR TITLE
Remove _id from example user schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,6 @@ Schema.UserProfile = new SimpleSchema({
 });
 
 Schema.User = new SimpleSchema({
-    _id: {
-        type: String,
-        regEx: SimpleSchema.RegEx.Id
-    },
     username: {
         type: String,
         regEx: /^[a-z0-9A-Z_]{3,15}$/


### PR DESCRIPTION
Examples works without _id.

Including _id causes problems with quickForm template.
