### PR TITLE
Add support for MongoDB text index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,13 @@ Set to `1` or `true` for an ascending index. Set to `-1` for a descending index.
 Or you may set this to another type of specific MongoDB index, such as `"2d"`.
 Indexes works on embedded sub-documents as well.
 
+Note that `text` index work differently. There can be only one `text` index per
+MongoDB collection. When using `index: 'text'` you can optionally include the
+`indexWeight: num` option. Where `num` is an integer greater than zero. Defaults
+to 1. This is the relative weight compared to all the fields that have the `text`
+index. See the MongoDB [docs](http://docs.mongodb.org/manual/tutorial/control-results-of-text-search/).
+If any one of the fields has `sparse: true` then the index will have `sparse: true`.
+
 If you have created an index for a field by mistake and you want to remove it,
 set `index` to `false`:
 

--- a/package.js
+++ b/package.js
@@ -1,9 +1,9 @@
 /* global Package */
 
 Package.describe({
-  name: "aldeed:collection2",
+  name: "kdorsel:collection2",
   summary: "Automatic validation of insert and update operations on the client and server.",
-  version: "2.3.3",
+  version: "2.3.4",
   git: "https://github.com/aldeed/meteor-collection2.git"
 });
 
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
 
   // Allow us to detect 'insecure'.
   api.use('insecure@1.0.0', {weak: true});
-  
+
   api.addFiles(['collection2.js']);
 });
 

--- a/tests/schemas.js
+++ b/tests/schemas.js
@@ -7,7 +7,9 @@ booksSchema = new SimpleSchema({
   },
   author: {
     type: String,
-    label: "Author"
+    label: "Author",
+    index: 'text',
+    indexWeight: 5
   },
   copies: {
     type: Number,
@@ -23,7 +25,9 @@ booksSchema = new SimpleSchema({
     type: String,
     label: "Brief summary",
     optional: true,
-    max: 1000
+    max: 1000,
+    index: 'text',
+    indexWeight: 1
   },
   isbn: {
     type: String,


### PR DESCRIPTION
Currently when `index: 'text'` is used on more than one field it tries to create multiple text index. MongoDB only allows one text index per collection. This fixes that and also includes text index weights.
