### PR TITLE
Add support for 'pick' and 'omit' options in insert or update operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ To skip removing empty strings, set the `removeEmptyStrings` option to `false` w
 
 To skip adding automatic values, set the `getAutoValues` option to `false` when you call `insert` or `update`. This works only in server code.
 
+### Pick or omit from the attached schema
+
+To pick or omit fields from the schema for the operation, set the 'pick' or 'omit' option respectively to an array of schema field names. These options are mutually exclusive, so you cannot have both present in the options object at the same time.
+
 ## Inserting or Updating Bypassing Collection2 Entirely
 
 Even if you skip all validation and cleaning, Collection2 will still do some object parsing that can take a long time for a large document. To bypass this, set the `bypassCollection2` option to `true` when you call `insert` or `update`. This works only in server code.

--- a/package/collection2/collection2.js
+++ b/package/collection2/collection2.js
@@ -273,6 +273,19 @@ function doValidate(collection, type, args, getAutoValues, userId, isFromTrusted
   if ((Meteor.isServer || isLocalCollection) && options.getAutoValues === false) {
     getAutoValues = false;
   }
+  
+  // Process pick/omit options if they are present
+  var picks = Array.isArray(options.pick) ? options.pick : null,
+    omits = Array.isArray(options.omit) ? options.omit : null;
+
+  if (picks && omits) {
+    // Pick and omit cannot both be present in the options
+    throw new Error('pick and omit options are mutually exclusive');
+  } else if (picks) {
+    schema = schema.pick(...picks);
+  } else if (omits) {
+    schema = schema.omit(...omits);
+  }
 
   // Determine validation context
   var validationContext = options.validationContext;


### PR DESCRIPTION
Allow mutually exclusive pick/omit options for insert and update operations. This provides simple inline syntax and avoids needing to create a whole named context or separate schema just to limit the fields allowed in a given operation. Similarly to the 'keys' option, the value would be an array of field names that will be spread into the pick or omit function call when it is run. An error is thrown if both pick and omit are provided because there is no good way to determine which should go first.