### PR TITLE
Use meteor/ejson

### DIFF
--- a/package/collection2/collection2.js
+++ b/package/collection2/collection2.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 import clone from 'clone';
-import EJSON from 'ejson';
+import { EJSON } from 'meteor/ejson';
 import isEmpty from 'lodash.isempty';
 import isEqual from 'lodash.isequal';
 import isObject from 'lodash.isobject';

--- a/package/collection2/package.js
+++ b/package/collection2/package.js
@@ -10,7 +10,6 @@ Package.describe({
 
 Npm.depends({
   clone: '2.1.1',
-  ejson: '2.1.2',
   'lodash.isempty': '4.4.0',
   'lodash.isequal': '4.5.0',
   'lodash.isobject': '3.0.2',
@@ -19,9 +18,10 @@ Npm.depends({
 Package.onUse(function(api) {
   api.use('mongo@1.0.4');
   api.imply('mongo');
-  api.use('minimongo@1.0.0');
+  api.use('minimongo');
+  api.use('ejson');
   api.use('raix:eventemitter@0.1.3 || 1.0.0');
-  api.use('ecmascript@0.6.1');
+  api.use('ecmascript');
   api.use('tmeasday:check-npm-versions@0.3.1');
 
   // Allow us to detect 'insecure'.

--- a/package/collection2/package.js
+++ b/package/collection2/package.js
@@ -18,10 +18,10 @@ Npm.depends({
 Package.onUse(function(api) {
   api.use('mongo@1.0.4');
   api.imply('mongo');
-  api.use('minimongo');
+  api.use('minimongo@1.0.0');
   api.use('ejson');
   api.use('raix:eventemitter@0.1.3 || 1.0.0');
-  api.use('ecmascript');
+  api.use('ecmascript@0.6.1');
   api.use('tmeasday:check-npm-versions@0.3.1');
 
   // Allow us to detect 'insecure'.


### PR DESCRIPTION
This PR simply reduces some of the constraints, and switches to the EJSON bundled with Meteor, instead of pulling in an additional dependency from npm.