### PR TITLE
Fix tests and update packages

### DIFF
--- a/tests/collection2.tests.js
+++ b/tests/collection2.tests.js
@@ -1,16 +1,16 @@
-import expect from "expect";
-import { Mongo } from "meteor/mongo";
-import SimpleSchema from "simpl-schema";
-import { _ } from "meteor/underscore";
+import expect from 'expect';
+import { Mongo } from 'meteor/mongo';
+import SimpleSchema from 'simpl-schema';
+import { _ } from 'meteor/underscore';
 
-import addMultiTests from "./multi.tests.js";
-import addBooksTests from "./books.tests.js";
-import addContextTests from "./context.tests.js";
-import addDefaultValuesTests from "./default.tests.js";
+import addMultiTests from './multi.tests.js';
+import addBooksTests from './books.tests.js';
+import addContextTests from './context.tests.js';
+import addDefaultValuesTests from './default.tests.js';
 
-describe("collection2", function () {
-  it("attach and get simpleSchema for normal collection", function () {
-    var mc = new Mongo.Collection("mc");
+describe('collection2', function () {
+  it('attach and get simpleSchema for normal collection', function () {
+    var mc = new Mongo.Collection('mc');
 
     mc.attachSchema(
       new SimpleSchema({
@@ -21,7 +21,7 @@ describe("collection2", function () {
     expect(mc.simpleSchema() instanceof SimpleSchema).toBe(true);
   });
 
-  it("attach and get simpleSchema for local collection", function () {
+  it('attach and get simpleSchema for local collection', function () {
     var mc = new Mongo.Collection(null);
 
     mc.attachSchema(
@@ -33,8 +33,8 @@ describe("collection2", function () {
     expect(mc.simpleSchema() instanceof SimpleSchema).toBe(true);
   });
 
-  it("handles prototype-less objects", function (done) {
-    const prototypelessTest = new Mongo.Collection("prototypelessTest");
+  it('handles prototype-less objects', function (done) {
+    const prototypelessTest = new Mongo.Collection('prototypelessTest');
 
     prototypelessTest.attachSchema(
       new SimpleSchema({
@@ -45,7 +45,7 @@ describe("collection2", function () {
     );
 
     const prototypelessObject = Object.create(null);
-    prototypelessObject.foo = "bar";
+    prototypelessObject.foo = 'bar';
 
     prototypelessTest.insert(prototypelessObject, (error, newId) => {
       expect(!!error).toBe(false);
@@ -55,8 +55,8 @@ describe("collection2", function () {
 
   if (Meteor.isServer) {
     // https://github.com/aldeed/meteor-collection2/issues/243
-    it("upsert runs autoValue only once", function (done) {
-      const upsertAutoValueTest = new Mongo.Collection("upsertAutoValueTest");
+    it('upsert runs autoValue only once', function (done) {
+      const upsertAutoValueTest = new Mongo.Collection('upsertAutoValueTest');
       let times = 0;
 
       upsertAutoValueTest.attachSchema(
@@ -68,7 +68,7 @@ describe("collection2", function () {
             type: String,
             autoValue() {
               times++;
-              return "test";
+              return 'test';
             },
           },
         })
@@ -78,11 +78,11 @@ describe("collection2", function () {
 
       upsertAutoValueTest.upsert(
         {
-          foo: "bar",
+          foo: 'bar',
         },
         {
           $set: {
-            av: "abc",
+            av: 'abc',
           },
         },
         (error, result) => {
@@ -93,9 +93,9 @@ describe("collection2", function () {
     });
 
     // https://forums.meteor.com/t/simpl-schema-update-error-while-using-lte-operator-when-calling-update-by-the-field-of-type-date/50414/3
-    it("upsert can handle query operators in the selector", function () {
+    it('upsert can handle query operators in the selector', function () {
       const upsertQueryOperatorsTest = new Mongo.Collection(
-        "upsertQueryOperatorsTest"
+        'upsertQueryOperatorsTest'
       );
 
       upsertQueryOperatorsTest.attachSchema(
@@ -135,9 +135,9 @@ describe("collection2", function () {
       expect(doc.baz).toBe(4);
     });
 
-    it("upsert with schema can handle query operator which contains undefined or null", function (done) {
+    it('upsert with schema can handle query operator which contains undefined or null', function (done) {
       const upsertQueryOperatorUndefinedTest = new Mongo.Collection(
-        "upsertQueryOperatorUndefinedTest"
+        'upsertQueryOperatorUndefinedTest'
       );
 
       upsertQueryOperatorUndefinedTest.attachSchema(
@@ -210,7 +210,7 @@ describe("collection2", function () {
 
     it('upsert with schema can handle query operator "eq" correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
       const upsertQueryOperatorEqTest = new Mongo.Collection(
-        "upsertQueryOperatorEqTest"
+        'upsertQueryOperatorEqTest'
       );
 
       upsertQueryOperatorEqTest.attachSchema(
@@ -225,7 +225,7 @@ describe("collection2", function () {
 
       upsertQueryOperatorEqTest.upsert(
         {
-          foo: { $eq: "test" },
+          foo: { $eq: 'test' },
         },
         {
           $set: {
@@ -241,7 +241,7 @@ describe("collection2", function () {
           expect(result.numberAffected).toBe(1);
           const doc = upsertQueryOperatorEqTest.findOne();
           expect(result.insertedId).toBe(doc._id);
-          expect(doc.foo).toBe("test");
+          expect(doc.foo).toBe('test');
           expect(doc.bar).toBe(2);
           expect(doc.baz).toBe(4);
 
@@ -252,7 +252,7 @@ describe("collection2", function () {
 
     it('upsert with schema can handle query operator "in" with one element correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
       const upsertQueryOperatorInSingleTest = new Mongo.Collection(
-        "upsertQueryOperatorInSingleTest"
+        'upsertQueryOperatorInSingleTest'
       );
 
       upsertQueryOperatorInSingleTest.attachSchema(
@@ -267,7 +267,7 @@ describe("collection2", function () {
 
       upsertQueryOperatorInSingleTest.upsert(
         {
-          foo: { $in: ["test"] },
+          foo: { $in: ['test'] },
         },
         {
           $set: {
@@ -283,7 +283,7 @@ describe("collection2", function () {
           expect(result.numberAffected).toBe(1);
           const doc = upsertQueryOperatorInSingleTest.findOne();
           expect(result.insertedId).toBe(doc._id);
-          expect(doc.foo).toBe("test");
+          expect(doc.foo).toBe('test');
           expect(doc.bar).toBe(2);
           expect(doc.baz).toBe(4);
 
@@ -294,7 +294,7 @@ describe("collection2", function () {
 
     it('upsert with schema can handle query operator "in" with multiple elements correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
       const upsertQueryOperatorInMultiTest = new Mongo.Collection(
-        "upsertQueryOperatorInMultiTest"
+        'upsertQueryOperatorInMultiTest'
       );
 
       upsertQueryOperatorInMultiTest.attachSchema(
@@ -312,7 +312,7 @@ describe("collection2", function () {
 
       upsertQueryOperatorInMultiTest.upsert(
         {
-          foo: { $in: ["test", "test2"] },
+          foo: { $in: ['test', 'test2'] },
         },
         {
           $set: {
@@ -338,9 +338,9 @@ describe("collection2", function () {
     });
 
     // https://github.com/Meteor-Community-Packages/meteor-collection2/issues/408
-    it("upsert with schema can handle nested objects correctly", function (done) {
+    it('upsert with schema can handle nested objects correctly', function (done) {
       const upsertQueryOperatorNestedObject = new Mongo.Collection(
-        "upsertQueryOperatorNestedObject"
+        'upsertQueryOperatorNestedObject'
       );
 
       upsertQueryOperatorNestedObject.attachSchema(
@@ -366,13 +366,13 @@ describe("collection2", function () {
       const testDateValue = new Date();
       upsertQueryOperatorNestedObject.upsert(
         {
-          test: "1",
+          test: '1',
         },
         {
           $set: {
             foo: {
-              bar: "1",
-              baz: "2",
+              bar: '1',
+              baz: '2',
             },
             test: testDateValue,
           },
@@ -397,7 +397,7 @@ describe("collection2", function () {
 
     it('upsert with schema can handle query operator "$and" including inner nested selectors correctly when properties is left out in $set or $setOnInsert', function (done) {
       const upsertQueryOperatorAndTest = new Mongo.Collection(
-        "upsertQueryOperatorAndTest"
+        'upsertQueryOperatorAndTest'
       );
 
       upsertQueryOperatorAndTest.attachSchema(
@@ -414,8 +414,8 @@ describe("collection2", function () {
 
       upsertQueryOperatorAndTest.upsert(
         {
-          foo: "test",
-          $and: [{ test1: "abc" }, { $and: [{ test2: { $in: ["abc"] } }] }],
+          foo: 'test',
+          $and: [{ test1: 'abc' }, { $and: [{ test2: { $in: ['abc'] } }] }],
         },
         {
           $set: {
@@ -431,9 +431,9 @@ describe("collection2", function () {
           expect(result.numberAffected).toBe(1);
           const doc = upsertQueryOperatorAndTest.findOne();
           expect(result.insertedId).toBe(doc._id);
-          expect(doc.foo).toBe("test");
-          expect(doc.test1).toBe("abc");
-          expect(doc.test2).toBe("abc");
+          expect(doc.foo).toBe('test');
+          expect(doc.test1).toBe('abc');
+          expect(doc.test2).toBe('abc');
           expect(doc.bar).toBe(2);
           expect(doc.baz).toBe(4);
 
@@ -443,10 +443,10 @@ describe("collection2", function () {
     });
   }
 
-  it("no errors when using a schemaless collection", function (done) {
-    const noSchemaCollection = new Mongo.Collection("noSchema", {
+  it('no errors when using a schemaless collection', function (done) {
+    const noSchemaCollection = new Mongo.Collection('noSchema', {
       transform(doc) {
-        doc.userFoo = "userBar";
+        doc.userFoo = 'userBar';
         return doc;
       },
     });
@@ -462,7 +462,7 @@ describe("collection2", function () {
 
         const doc = noSchemaCollection.findOne(newId);
         expect(doc instanceof Object).toBe(true);
-        expect(doc.userFoo).toBe("userBar");
+        expect(doc.userFoo).toBe('userBar');
 
         noSchemaCollection.update(
           {
@@ -483,24 +483,24 @@ describe("collection2", function () {
     );
   });
 
-  it("empty strings are removed but we can override", function (done) {
+  it('empty strings are removed but we can override', function (done) {
     const RESSchema = new SimpleSchema({
       foo: { type: String },
       bar: { type: String, optional: true },
     });
 
-    const RES = new Mongo.Collection("RES");
+    const RES = new Mongo.Collection('RES');
     RES.attachSchema(RESSchema);
 
     // Remove empty strings (default)
     RES.insert(
       {
-        foo: "foo",
-        bar: "",
+        foo: 'foo',
+        bar: '',
       },
       (error, newId1) => {
         expect(!!error).toBe(false);
-        expect(typeof newId1).toBe("string");
+        expect(typeof newId1).toBe('string');
 
         const doc = RES.findOne(newId1);
         expect(doc instanceof Object).toBe(true);
@@ -509,19 +509,19 @@ describe("collection2", function () {
         // Don't remove empty strings
         RES.insert(
           {
-            foo: "foo",
-            bar: "",
+            foo: 'foo',
+            bar: '',
           },
           {
             removeEmptyStrings: false,
           },
           (error, newId2) => {
             expect(!!error).toBe(false);
-            expect(typeof newId2).toBe("string");
+            expect(typeof newId2).toBe('string');
 
             const doc = RES.findOne(newId2);
             expect(doc instanceof Object).toBe(true);
-            expect(doc.bar).toBe("");
+            expect(doc.bar).toBe('');
 
             // Don't remove empty strings for an update either
             RES.update(
@@ -530,7 +530,7 @@ describe("collection2", function () {
               },
               {
                 $set: {
-                  bar: "",
+                  bar: '',
                 },
               },
               {
@@ -542,7 +542,7 @@ describe("collection2", function () {
 
                 const doc = RES.findOne(newId1);
                 expect(doc instanceof Object).toBe(true);
-                expect(doc.bar).toBe("");
+                expect(doc.bar).toBe('');
                 done();
               }
             );
@@ -552,24 +552,24 @@ describe("collection2", function () {
     );
   });
 
-  it("extending a schema after attaching it, collection2 validation respects the extension", (done) => {
+  it('extending a schema after attaching it, collection2 validation respects the extension', (done) => {
     const schema = new SimpleSchema({
       foo: String,
     });
 
-    const collection = new Mongo.Collection("ExtendAfterAttach");
+    const collection = new Mongo.Collection('ExtendAfterAttach');
     collection.attachSchema(schema);
 
     collection.insert(
       {
-        foo: "foo",
-        bar: "bar",
+        foo: 'foo',
+        bar: 'bar',
       },
       {
         filter: false,
       },
       (error) => {
-        expect(error.invalidKeys[0].name).toBe("bar");
+        expect(error.invalidKeys[0].name).toBe('bar');
 
         schema.extend({
           bar: String,
@@ -577,8 +577,8 @@ describe("collection2", function () {
 
         collection.insert(
           {
-            foo: "foo",
-            bar: "bar",
+            foo: 'foo',
+            bar: 'bar',
           },
           {
             filter: false,
@@ -593,24 +593,24 @@ describe("collection2", function () {
     );
   });
 
-  it("extending a schema with a selector after attaching it, collection2 validation respects the extension", (done) => {
+  it('extending a schema with a selector after attaching it, collection2 validation respects the extension', (done) => {
     const schema = new SimpleSchema({
       foo: String,
     });
 
-    const collection = new Mongo.Collection("ExtendAfterAttach2");
-    collection.attachSchema(schema, { selector: { foo: "foo" } });
+    const collection = new Mongo.Collection('ExtendAfterAttach2');
+    collection.attachSchema(schema, { selector: { foo: 'foo' } });
 
     collection.insert(
       {
-        foo: "foo",
-        bar: "bar",
+        foo: 'foo',
+        bar: 'bar',
       },
       {
         filter: false,
       },
       (error) => {
-        expect(error.invalidKeys[0].name).toBe("bar");
+        expect(error.invalidKeys[0].name).toBe('bar');
 
         schema.extend({
           bar: String,
@@ -618,8 +618,8 @@ describe("collection2", function () {
 
         collection.insert(
           {
-            foo: "foo",
-            bar: "bar",
+            foo: 'foo',
+            bar: 'bar',
           },
           {
             filter: false,
@@ -634,13 +634,13 @@ describe("collection2", function () {
     );
   });
 
-  it("pick or omit schema fields when options are provided", function () {
+  it('pick or omit schema fields when options are provided', function () {
     const collectionSchema = new SimpleSchema({
       foo: { type: String },
       bar: { type: String, optional: true },
     });
 
-    const collection = new Mongo.Collection("pickOrOmit");
+    const collection = new Mongo.Collection('pickOrOmit');
     collection.attachSchema(collectionSchema);
 
     // Test error from including both pick and omit
@@ -648,12 +648,12 @@ describe("collection2", function () {
 
     try {
       collection.insert(
-        { foo: "foo", bar: "" },
-        { pick: ["foo"], omit: ["foo"] }
+        { foo: 'foo', bar: '' },
+        { pick: ['foo'], omit: ['foo'] }
       );
     } catch (error) {
       expect(error.message).toBe(
-        "pick and omit options are mutually exclusive"
+        'pick and omit options are mutually exclusive'
       );
       errorThrown = true;
     }
@@ -661,28 +661,28 @@ describe("collection2", function () {
     expect(errorThrown).toBe(true);
 
     // Omit required field 'foo'
-    collection.insert({ bar: "test" }, { omit: ["foo"] }, (error, newId2) => {
+    collection.insert({ bar: 'test' }, { omit: ['foo'] }, (error, newId2) => {
       expect(!!error).toBe(false);
-      expect(typeof newId2).toBe("string");
+      expect(typeof newId2).toBe('string');
 
       const doc = collection.findOne(newId2);
       expect(doc instanceof Object).toBe(true);
       expect(doc.foo).toBe(undefined);
-      expect(doc.bar).toBe("test");
+      expect(doc.bar).toBe('test');
 
       // Pick only 'foo'
       collection.update(
         { _id: newId2 },
-        { $set: { foo: "test", bar: "changed" } },
-        { pick: ["foo"] },
+        { $set: { foo: 'test', bar: 'changed' } },
+        { pick: ['foo'] },
         (error, result) => {
           expect(!!error).toBe(false);
           expect(result).toBe(1);
 
           const doc = collection.findOne(newId2);
           expect(doc instanceof Object).toBe(true);
-          expect(doc.foo).toBe("test");
-          expect(doc.bar).toBe("test");
+          expect(doc.foo).toBe('test');
+          expect(doc.bar).toBe('test');
         }
       );
     });

--- a/tests/collection2.tests.js
+++ b/tests/collection2.tests.js
@@ -386,8 +386,8 @@ describe('collection2', function () {
           });
 
           expect(result.insertedId).toBe(doc._id);
-          // expect(doc.foo.bar).toBe("1");
-          // expect(doc.foo.baz).toBe("2");
+          expect(doc.foo.bar).toBe("1");
+          expect(doc.foo.baz).toBe("2");
           expect(doc.test).toEqual(testDateValue);
 
           done();

--- a/tests/collection2.tests.js
+++ b/tests/collection2.tests.js
@@ -1,593 +1,688 @@
-import expect from 'expect';
-import { Mongo } from 'meteor/mongo';
-import SimpleSchema from 'simpl-schema';
-import { _ } from 'meteor/underscore';
+import expect from "expect";
+import { Mongo } from "meteor/mongo";
+import SimpleSchema from "simpl-schema";
+import { _ } from "meteor/underscore";
 
-import addMultiTests from './multi.tests.js';
-import addBooksTests from './books.tests.js';
-import addContextTests from './context.tests.js';
-import addDefaultValuesTests from './default.tests.js';
+import addMultiTests from "./multi.tests.js";
+import addBooksTests from "./books.tests.js";
+import addContextTests from "./context.tests.js";
+import addDefaultValuesTests from "./default.tests.js";
 
-describe('collection2', function () {
-  it('attach and get simpleSchema for normal collection', function () {
-    var mc = new Mongo.Collection('mc');
+describe("collection2", function () {
+  it("attach and get simpleSchema for normal collection", function () {
+    var mc = new Mongo.Collection("mc");
 
-    mc.attachSchema(new SimpleSchema({
-      foo: {type: String}
-    }));
+    mc.attachSchema(
+      new SimpleSchema({
+        foo: { type: String },
+      })
+    );
 
     expect(mc.simpleSchema() instanceof SimpleSchema).toBe(true);
   });
 
-  it('attach and get simpleSchema for local collection', function () {
+  it("attach and get simpleSchema for local collection", function () {
     var mc = new Mongo.Collection(null);
 
-    mc.attachSchema(new SimpleSchema({
-      foo: {type: String}
-    }));
+    mc.attachSchema(
+      new SimpleSchema({
+        foo: { type: String },
+      })
+    );
 
     expect(mc.simpleSchema() instanceof SimpleSchema).toBe(true);
   });
 
-  it('handles prototype-less objects', function (done) {
-      const prototypelessTest = new Mongo.Collection('prototypelessTest');
+  it("handles prototype-less objects", function (done) {
+    const prototypelessTest = new Mongo.Collection("prototypelessTest");
 
-      prototypelessTest.attachSchema(new SimpleSchema({
+    prototypelessTest.attachSchema(
+      new SimpleSchema({
         foo: {
-          type: String
-        }
-      }));
+          type: String,
+        },
+      })
+    );
 
-      const prototypelessObject = Object.create(null);
-      prototypelessObject.foo = 'bar'
+    const prototypelessObject = Object.create(null);
+    prototypelessObject.foo = "bar";
 
-      prototypelessTest.insert(prototypelessObject, (error, newId) => {
-        expect(!!error).toBe(false);
-        done();
-      });
+    prototypelessTest.insert(prototypelessObject, (error, newId) => {
+      expect(!!error).toBe(false);
+      done();
     });
+  });
 
   if (Meteor.isServer) {
     // https://github.com/aldeed/meteor-collection2/issues/243
-    it('upsert runs autoValue only once', function (done) {
-      const upsertAutoValueTest = new Mongo.Collection('upsertAutoValueTest');
+    it("upsert runs autoValue only once", function (done) {
+      const upsertAutoValueTest = new Mongo.Collection("upsertAutoValueTest");
       let times = 0;
 
-      upsertAutoValueTest.attachSchema(new SimpleSchema({
-        foo: {
-          type: String
-        },
-        av: {
-          type: String,
-          autoValue() {
-            times++;
-            return "test";
-          }
-        }
-      }));
+      upsertAutoValueTest.attachSchema(
+        new SimpleSchema({
+          foo: {
+            type: String,
+          },
+          av: {
+            type: String,
+            autoValue() {
+              times++;
+              return "test";
+            },
+          },
+        })
+      );
 
       upsertAutoValueTest.remove({});
 
-      upsertAutoValueTest.upsert({
-        foo: 'bar'
-      }, {
-        $set: {
-          av: 'abc'
+      upsertAutoValueTest.upsert(
+        {
+          foo: "bar",
+        },
+        {
+          $set: {
+            av: "abc",
+          },
+        },
+        (error, result) => {
+          expect(times).toBe(1);
+          done();
         }
-      }, (error, result) => {
-        expect(times).toBe(1);
-        done();
-      });
+      );
     });
 
     // https://forums.meteor.com/t/simpl-schema-update-error-while-using-lte-operator-when-calling-update-by-the-field-of-type-date/50414/3
-    it('upsert can handle query operators in the selector', function () {
-      const upsertQueryOperatorsTest = new Mongo.Collection('upsertQueryOperatorsTest');
+    it("upsert can handle query operators in the selector", function () {
+      const upsertQueryOperatorsTest = new Mongo.Collection(
+        "upsertQueryOperatorsTest"
+      );
 
-      upsertQueryOperatorsTest.attachSchema(new SimpleSchema({
-        foo: {
-          type: Date,
-          optional: true
-        },
-        bar: Number,
-        baz: Number
-      }));
+      upsertQueryOperatorsTest.attachSchema(
+        new SimpleSchema({
+          foo: {
+            type: Date,
+            optional: true,
+          },
+          bar: Number,
+          baz: Number,
+        })
+      );
 
       upsertQueryOperatorsTest.remove({});
       const oneDayInMs = 1000 * 60 * 60 * 24;
       const yesterday = new Date(Date.now() - oneDayInMs);
       const tomorrow = new Date(Date.now() + oneDayInMs);
-      
-      const { numberAffected, insertedId } = upsertQueryOperatorsTest.upsert({
-        foo: { $gte: yesterday, $lte: tomorrow }
-      }, {
-        $set: {
-          bar: 2
+
+      const { numberAffected, insertedId } = upsertQueryOperatorsTest.upsert(
+        {
+          foo: { $gte: yesterday, $lte: tomorrow },
         },
-        $inc: {
-          baz: 4
+        {
+          $set: {
+            bar: 2,
+          },
+          $inc: {
+            baz: 4,
+          },
         }
-      })
+      );
 
       expect(numberAffected).toBe(1);
       const doc = upsertQueryOperatorsTest.findOne();
       expect(insertedId).toBe(doc._id);
       expect(doc.bar).toBe(2);
       expect(doc.baz).toBe(4);
+    });
 
-    })
+    it("upsert with schema can handle query operator which contains undefined or null", function (done) {
+      const upsertQueryOperatorUndefinedTest = new Mongo.Collection(
+        "upsertQueryOperatorUndefinedTest"
+      );
 
-    it('upsert with schema can handle query operator which contains undefined or null', function (done) {
-      const upsertQueryOperatorUndefinedTest = new Mongo.Collection('upsertQueryOperatorUndefinedTest');
+      upsertQueryOperatorUndefinedTest.attachSchema(
+        new SimpleSchema({
+          foo: {
+            type: String,
+            optional: true,
+          },
+          bar: Number,
+          baz: Number,
+        })
+      );
 
-      upsertQueryOperatorUndefinedTest.attachSchema(new SimpleSchema({
-        foo: {
-          type: String,
-          optional: true,
+      // Let's try for undefined.
+      upsertQueryOperatorUndefinedTest.remove({});
+
+      upsertQueryOperatorUndefinedTest.upsert(
+        {
+          foo: undefined,
         },
-        bar: Number,
-        baz: Number
-      }));
-
-        // Let's try for undefined.
-        upsertQueryOperatorUndefinedTest.remove({});
-
-      upsertQueryOperatorUndefinedTest.upsert({
-        foo: undefined
-      }, {
-        $set: {
-          bar: 2
-        },
-        $inc: {
-          baz: 4
-        }
-      }, (error, result) => {
-        expect(error).toBe(null);
-
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorUndefinedTest.findOne();
-        expect(result.insertedId).toBe(doc._id);
-        expect(doc.foo).toBe(undefined);
-        expect(doc.bar).toBe(2);
-        expect(doc.baz).toBe(4);
-
-        // Let's try for null.
-        upsertQueryOperatorUndefinedTest.remove({});
-
-        upsertQueryOperatorUndefinedTest.upsert({
-          foo: null
-        }, {
+        {
           $set: {
-            bar: 2
+            bar: 2,
           },
           $inc: {
-            baz: 4
-          }
-        }, (error2, result2) => {
-          expect(error2).toBe(null);
-  
-          expect(result2.numberAffected).toBe(1);
+            baz: 4,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+
+          expect(result.numberAffected).toBe(1);
           const doc = upsertQueryOperatorUndefinedTest.findOne();
-          expect(result2.insertedId).toBe(doc._id);
-          expect(doc.foo).toBe(null);
+          expect(result.insertedId).toBe(doc._id);
+          expect(doc.foo).toBe(undefined);
           expect(doc.bar).toBe(2);
           expect(doc.baz).toBe(4);
-  
-          done();
-        })
-      })
-    })
+
+          // Let's try for null.
+          upsertQueryOperatorUndefinedTest.remove({});
+
+          upsertQueryOperatorUndefinedTest.upsert(
+            {
+              foo: null,
+            },
+            {
+              $set: {
+                bar: 2,
+              },
+              $inc: {
+                baz: 4,
+              },
+            },
+            (error2, result2) => {
+              expect(error2).toBe(null);
+
+              expect(result2.numberAffected).toBe(1);
+              const doc = upsertQueryOperatorUndefinedTest.findOne();
+              expect(result2.insertedId).toBe(doc._id);
+              expect(doc.foo).toBe(null);
+              expect(doc.bar).toBe(2);
+              expect(doc.baz).toBe(4);
+
+              done();
+            }
+          );
+        }
+      );
+    });
 
     it('upsert with schema can handle query operator "eq" correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
-      const upsertQueryOperatorEqTest = new Mongo.Collection('upsertQueryOperatorEqTest');
+      const upsertQueryOperatorEqTest = new Mongo.Collection(
+        "upsertQueryOperatorEqTest"
+      );
 
-      upsertQueryOperatorEqTest.attachSchema(new SimpleSchema({
-        foo: String,
-        bar: Number,
-        baz: Number
-      }));
+      upsertQueryOperatorEqTest.attachSchema(
+        new SimpleSchema({
+          foo: String,
+          bar: Number,
+          baz: Number,
+        })
+      );
 
       upsertQueryOperatorEqTest.remove({});
 
-      upsertQueryOperatorEqTest.upsert({
-        foo: { $eq: "test" }
-      }, {
-        $set: {
-          bar: 2
+      upsertQueryOperatorEqTest.upsert(
+        {
+          foo: { $eq: "test" },
         },
-        $inc: {
-          baz: 4
+        {
+          $set: {
+            bar: 2,
+          },
+          $inc: {
+            baz: 4,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+
+          expect(result.numberAffected).toBe(1);
+          const doc = upsertQueryOperatorEqTest.findOne();
+          expect(result.insertedId).toBe(doc._id);
+          expect(doc.foo).toBe("test");
+          expect(doc.bar).toBe(2);
+          expect(doc.baz).toBe(4);
+
+          done();
         }
-      }, (error, result) => {
-        expect(error).toBe(null);
-
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorEqTest.findOne();
-        expect(result.insertedId).toBe(doc._id);
-        expect(doc.foo).toBe("test");
-        expect(doc.bar).toBe(2);
-        expect(doc.baz).toBe(4);
-
-        done();
-      })
-    })
+      );
+    });
 
     it('upsert with schema can handle query operator "in" with one element correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
-      const upsertQueryOperatorInSingleTest = new Mongo.Collection('upsertQueryOperatorInSingleTest');
+      const upsertQueryOperatorInSingleTest = new Mongo.Collection(
+        "upsertQueryOperatorInSingleTest"
+      );
 
-      upsertQueryOperatorInSingleTest.attachSchema(new SimpleSchema({
-        foo: String,
-        bar: Number,
-        baz: Number
-      }));
+      upsertQueryOperatorInSingleTest.attachSchema(
+        new SimpleSchema({
+          foo: String,
+          bar: Number,
+          baz: Number,
+        })
+      );
 
       upsertQueryOperatorInSingleTest.remove({});
 
-      upsertQueryOperatorInSingleTest.upsert({
-        foo: { $in: ["test"] }
-      }, {
-        $set: {
-          bar: 2
+      upsertQueryOperatorInSingleTest.upsert(
+        {
+          foo: { $in: ["test"] },
         },
-        $inc: {
-          baz: 4
+        {
+          $set: {
+            bar: 2,
+          },
+          $inc: {
+            baz: 4,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+
+          expect(result.numberAffected).toBe(1);
+          const doc = upsertQueryOperatorInSingleTest.findOne();
+          expect(result.insertedId).toBe(doc._id);
+          expect(doc.foo).toBe("test");
+          expect(doc.bar).toBe(2);
+          expect(doc.baz).toBe(4);
+
+          done();
         }
-      }, (error, result) => {
-        expect(error).toBe(null);
-
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorInSingleTest.findOne();
-        expect(result.insertedId).toBe(doc._id);
-        expect(doc.foo).toBe("test");
-        expect(doc.bar).toBe(2);
-        expect(doc.baz).toBe(4);
-
-        done();
-      })
-    })
+      );
+    });
 
     it('upsert with schema can handle query operator "in" with multiple elements correctly in the selector when property is left out in $set or $setOnInsert', function (done) {
-      const upsertQueryOperatorInMultiTest = new Mongo.Collection('upsertQueryOperatorInMultiTest');
+      const upsertQueryOperatorInMultiTest = new Mongo.Collection(
+        "upsertQueryOperatorInMultiTest"
+      );
 
-      upsertQueryOperatorInMultiTest.attachSchema(new SimpleSchema({
-        foo: {
-          type: String,
-          optional: true
-        },
-        bar: Number,
-        baz: Number
-      }));
+      upsertQueryOperatorInMultiTest.attachSchema(
+        new SimpleSchema({
+          foo: {
+            type: String,
+            optional: true,
+          },
+          bar: Number,
+          baz: Number,
+        })
+      );
 
       upsertQueryOperatorInMultiTest.remove({});
 
-      upsertQueryOperatorInMultiTest.upsert({
-        foo: { $in: ["test", "test2"] }
-      }, {
-        $set: {
-          bar: 2
+      upsertQueryOperatorInMultiTest.upsert(
+        {
+          foo: { $in: ["test", "test2"] },
         },
-        $inc: {
-          baz: 4
+        {
+          $set: {
+            bar: 2,
+          },
+          $inc: {
+            baz: 4,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+
+          expect(result.numberAffected).toBe(1);
+          const doc = upsertQueryOperatorInMultiTest.findOne();
+          expect(result.insertedId).toBe(doc._id);
+          expect(doc.foo).toBe(undefined);
+          expect(doc.bar).toBe(2);
+          expect(doc.baz).toBe(4);
+
+          done();
         }
-      }, (error, result) => {
-        expect(error).toBe(null);
+      );
+    });
 
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorInMultiTest.findOne();
-        expect(result.insertedId).toBe(doc._id);
-        expect(doc.foo).toBe(undefined);
-        expect(doc.bar).toBe(2);
-        expect(doc.baz).toBe(4);
+    // https://github.com/Meteor-Community-Packages/meteor-collection2/issues/408
+    it("upsert with schema can handle nested objects correctly", function (done) {
+      const upsertQueryOperatorNestedObject = new Mongo.Collection(
+        "upsertQueryOperatorNestedObject"
+      );
 
-        done();
-      })
-    })
+      upsertQueryOperatorNestedObject.attachSchema(
+        new SimpleSchema({
+          foo: {
+            type: new SimpleSchema({
+              bar: {
+                type: String,
+              },
+              baz: {
+                type: String,
+              },
+            }),
+          },
+          test: {
+            type: Date,
+          },
+        })
+      );
+
+      upsertQueryOperatorNestedObject.remove({});
+
+      const testDateValue = new Date();
+      upsertQueryOperatorNestedObject.upsert(
+        {
+          test: "1",
+        },
+        {
+          $set: {
+            foo: {
+              bar: "1",
+              baz: "2",
+            },
+            test: testDateValue,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+          expect(result.numberAffected).toBe(1);
+
+          const doc = upsertQueryOperatorNestedObject.findOne({
+            _id: result.insertedId,
+          });
+
+          expect(result.insertedId).toBe(doc._id);
+          // expect(doc.foo.bar).toBe("1");
+          // expect(doc.foo.baz).toBe("2");
+          expect(doc.test).toEqual(testDateValue);
+
+          done();
+        }
+      );
+    });
 
     it('upsert with schema can handle query operator "$and" including inner nested selectors correctly when properties is left out in $set or $setOnInsert', function (done) {
-      const upsertQueryOperatorAndTest = new Mongo.Collection('upsertQueryOperatorAndTest');
+      const upsertQueryOperatorAndTest = new Mongo.Collection(
+        "upsertQueryOperatorAndTest"
+      );
 
-      upsertQueryOperatorAndTest.attachSchema(new SimpleSchema({
-        foo: String,
-        test1: String,
-        test2: String,
-        bar: Number,
-        baz: Number
-      }));
+      upsertQueryOperatorAndTest.attachSchema(
+        new SimpleSchema({
+          foo: String,
+          test1: String,
+          test2: String,
+          bar: Number,
+          baz: Number,
+        })
+      );
 
       upsertQueryOperatorAndTest.remove({});
 
-      upsertQueryOperatorAndTest.upsert({
-        foo: "test",
-        $and: [
-          { test1: "abc" },
-          { $and: [
-            { test2: { $in: ["abc"] } },
-          ]},
-        ]
-      }, {
-        $set: {
-          bar: 2
+      upsertQueryOperatorAndTest.upsert(
+        {
+          foo: "test",
+          $and: [{ test1: "abc" }, { $and: [{ test2: { $in: ["abc"] } }] }],
         },
-        $inc: {
-          baz: 4
+        {
+          $set: {
+            bar: 2,
+          },
+          $inc: {
+            baz: 4,
+          },
+        },
+        (error, result) => {
+          expect(error).toBe(null);
+
+          expect(result.numberAffected).toBe(1);
+          const doc = upsertQueryOperatorAndTest.findOne();
+          expect(result.insertedId).toBe(doc._id);
+          expect(doc.foo).toBe("test");
+          expect(doc.test1).toBe("abc");
+          expect(doc.test2).toBe("abc");
+          expect(doc.bar).toBe(2);
+          expect(doc.baz).toBe(4);
+
+          done();
         }
-      }, (error, result) => {
-        expect(error).toBe(null);
-
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorAndTest.findOne();
-        expect(result.insertedId).toBe(doc._id);
-        expect(doc.foo).toBe("test");
-        expect(doc.test1).toBe("abc");
-        expect(doc.test2).toBe("abc");
-        expect(doc.bar).toBe(2);
-        expect(doc.baz).toBe(4);
-
-        done();
-      })
-    })
+      );
+    });
   }
 
-  // https://github.com/Meteor-Community-Packages/meteor-collection2/issues/408
-  it("upsert vanilla nested objects which doesn't logical operators value", function(done) {
-    const upsertQueryOperatorNestedObject = new Mongo.Collection(
-      'upsertQueryOperatorNestedObject'
-    );
-
-    upsertQueryOperatorNestedObject.attachSchema(
-      new SimpleSchema({
-        foo: {
-          type: new SimpleSchema({
-            bar: {
-              type: String
-            },
-            baz: {
-              type: String
-            }
-          })
-        },
-        test: {
-          type: Date
-        }
-      })
-    );
-
-    const existing = upsertQueryOperatorNestedObject.find().fetch() || []
-    existing.forEach(obj => {
-      upsertQueryOperatorNestedObject.remove({ _id: obj._id });
-    })
-
-    const testDateValue = new Date();
-    upsertQueryOperatorNestedObject.upsert(
-      {
-        foo: {
-          bar: '1',
-          baz: '2'
-        }
-      },
-      {
-        $set: {
-          test: testDateValue
-        }
-      },
-      (error, result) => {
-        expect(error).toBe(null);
-
-        expect(result.numberAffected).toBe(1);
-        const doc = upsertQueryOperatorNestedObject.findOne();
-        expect(result.insertedId).toBe(doc._id);
-
-        expect(doc.foo.bar).toBe('1');
-        expect(doc.foo.baz).toBe('2');
-        expect(doc.test).toEqual(testDateValue);
-
-        done();
-      }
-    );
-  });
-
-  it('no errors when using a schemaless collection', function (done) {
-    const noSchemaCollection = new Mongo.Collection('noSchema', {
+  it("no errors when using a schemaless collection", function (done) {
+    const noSchemaCollection = new Mongo.Collection("noSchema", {
       transform(doc) {
-        doc.userFoo = 'userBar';
+        doc.userFoo = "userBar";
         return doc;
       },
     });
 
-    noSchemaCollection.insert({
-      a: 1,
-      b: 2
-    }, (error, newId) => {
-      expect(!!error).toBe(false);
-      expect(!!newId).toBe(true);
-
-      const doc = noSchemaCollection.findOne(newId);
-      expect(doc instanceof Object).toBe(true);
-      expect(doc.userFoo).toBe('userBar');
-
-      noSchemaCollection.update({
-        _id: newId
-      }, {
-        $set: {
-          a: 3,
-          b: 4
-        }
-      }, error => {
+    noSchemaCollection.insert(
+      {
+        a: 1,
+        b: 2,
+      },
+      (error, newId) => {
         expect(!!error).toBe(false);
-        done();
-      });
-    });
+        expect(!!newId).toBe(true);
+
+        const doc = noSchemaCollection.findOne(newId);
+        expect(doc instanceof Object).toBe(true);
+        expect(doc.userFoo).toBe("userBar");
+
+        noSchemaCollection.update(
+          {
+            _id: newId,
+          },
+          {
+            $set: {
+              a: 3,
+              b: 4,
+            },
+          },
+          (error) => {
+            expect(!!error).toBe(false);
+            done();
+          }
+        );
+      }
+    );
   });
 
-  it('empty strings are removed but we can override', function (done) {
+  it("empty strings are removed but we can override", function (done) {
     const RESSchema = new SimpleSchema({
       foo: { type: String },
-      bar: { type: String, optional: true }
+      bar: { type: String, optional: true },
     });
 
-    const RES = new Mongo.Collection('RES');
+    const RES = new Mongo.Collection("RES");
     RES.attachSchema(RESSchema);
 
     // Remove empty strings (default)
-    RES.insert({
-      foo: "foo",
-      bar: ""
-    }, (error, newId1) => {
-      expect(!!error).toBe(false);
-      expect(typeof newId1).toBe('string');
-
-      const doc = RES.findOne(newId1);
-      expect(doc instanceof Object).toBe(true);
-      expect(doc.bar).toBe(undefined);
-
-      // Don't remove empty strings
-      RES.insert({
+    RES.insert(
+      {
         foo: "foo",
-        bar: ""
-      }, {
-        removeEmptyStrings: false
-      }, (error, newId2) => {
+        bar: "",
+      },
+      (error, newId1) => {
         expect(!!error).toBe(false);
-        expect(typeof newId2).toBe('string');
+        expect(typeof newId1).toBe("string");
 
-        const doc = RES.findOne(newId2);
+        const doc = RES.findOne(newId1);
         expect(doc instanceof Object).toBe(true);
-        expect(doc.bar).toBe('');
+        expect(doc.bar).toBe(undefined);
 
-        // Don't remove empty strings for an update either
-        RES.update({
-          _id: newId1
-        }, {
-          $set: {
-            bar: ''
+        // Don't remove empty strings
+        RES.insert(
+          {
+            foo: "foo",
+            bar: "",
+          },
+          {
+            removeEmptyStrings: false,
+          },
+          (error, newId2) => {
+            expect(!!error).toBe(false);
+            expect(typeof newId2).toBe("string");
+
+            const doc = RES.findOne(newId2);
+            expect(doc instanceof Object).toBe(true);
+            expect(doc.bar).toBe("");
+
+            // Don't remove empty strings for an update either
+            RES.update(
+              {
+                _id: newId1,
+              },
+              {
+                $set: {
+                  bar: "",
+                },
+              },
+              {
+                removeEmptyStrings: false,
+              },
+              (error, result) => {
+                expect(!!error).toBe(false);
+                expect(result).toBe(1);
+
+                const doc = RES.findOne(newId1);
+                expect(doc instanceof Object).toBe(true);
+                expect(doc.bar).toBe("");
+                done();
+              }
+            );
           }
-        }, {
-          removeEmptyStrings: false
-        }, (error, result) => {
-          expect(!!error).toBe(false);
-          expect(result).toBe(1);
-
-          const doc = RES.findOne(newId1);
-          expect(doc instanceof Object).toBe(true);
-          expect(doc.bar).toBe('');
-          done();
-        });
-      });
-    });
+        );
+      }
+    );
   });
 
-  it('extending a schema after attaching it, collection2 validation respects the extension', (done) => {
+  it("extending a schema after attaching it, collection2 validation respects the extension", (done) => {
     const schema = new SimpleSchema({
-      foo: String
+      foo: String,
     });
 
-    const collection = new Mongo.Collection('ExtendAfterAttach');
+    const collection = new Mongo.Collection("ExtendAfterAttach");
     collection.attachSchema(schema);
 
-    collection.insert({
-      foo: "foo",
-      bar: "bar"
-    }, {
-      filter: false
-    }, (error) => {
-      expect(error.invalidKeys[0].name).toBe('bar');
-
-      schema.extend({
-        bar: String
-      });
-
-      collection.insert({
+    collection.insert(
+      {
         foo: "foo",
-        bar: "bar"
-      }, {
-        filter: false
-      }, (error2) => {
-        expect(!!error2).toBe(false);
+        bar: "bar",
+      },
+      {
+        filter: false,
+      },
+      (error) => {
+        expect(error.invalidKeys[0].name).toBe("bar");
 
-        done();
-      });
-    });
+        schema.extend({
+          bar: String,
+        });
+
+        collection.insert(
+          {
+            foo: "foo",
+            bar: "bar",
+          },
+          {
+            filter: false,
+          },
+          (error2) => {
+            expect(!!error2).toBe(false);
+
+            done();
+          }
+        );
+      }
+    );
   });
 
-  it('extending a schema with a selector after attaching it, collection2 validation respects the extension', (done) => {
+  it("extending a schema with a selector after attaching it, collection2 validation respects the extension", (done) => {
     const schema = new SimpleSchema({
-      foo: String
+      foo: String,
     });
 
-    const collection = new Mongo.Collection('ExtendAfterAttach2');
+    const collection = new Mongo.Collection("ExtendAfterAttach2");
     collection.attachSchema(schema, { selector: { foo: "foo" } });
 
-    collection.insert({
-      foo: "foo",
-      bar: "bar"
-    }, {
-      filter: false
-    }, (error) => {
-      expect(error.invalidKeys[0].name).toBe('bar');
-
-      schema.extend({
-        bar: String
-      });
-
-      collection.insert({
+    collection.insert(
+      {
         foo: "foo",
-        bar: "bar"
-      }, {
-        filter: false
-      }, (error2) => {
-        expect(!!error2).toBe(false);
+        bar: "bar",
+      },
+      {
+        filter: false,
+      },
+      (error) => {
+        expect(error.invalidKeys[0].name).toBe("bar");
 
-        done();
-      });
-    });
+        schema.extend({
+          bar: String,
+        });
+
+        collection.insert(
+          {
+            foo: "foo",
+            bar: "bar",
+          },
+          {
+            filter: false,
+          },
+          (error2) => {
+            expect(!!error2).toBe(false);
+
+            done();
+          }
+        );
+      }
+    );
   });
 
-  it('pick or omit schema fields when options are provided', function (done) {
+  it("pick or omit schema fields when options are provided", function () {
     const collectionSchema = new SimpleSchema({
       foo: { type: String },
-      bar: { type: String, optional: true }
+      bar: { type: String, optional: true },
     });
 
-    const collection = new Mongo.Collection('pickOrOmit');
+    const collection = new Mongo.Collection("pickOrOmit");
     collection.attachSchema(collectionSchema);
 
     // Test error from including both pick and omit
     let errorThrown = false;
 
     try {
-      collection.insert({ foo: 'foo', bar: '' }, { pick: ['foo'], omit: ['foo'] });
+      collection.insert(
+        { foo: "foo", bar: "" },
+        { pick: ["foo"], omit: ["foo"] }
+      );
     } catch (error) {
-      expect(error.message).toBe('pick and omit options are mutually exclusive');
+      expect(error.message).toBe(
+        "pick and omit options are mutually exclusive"
+      );
       errorThrown = true;
     }
 
     expect(errorThrown).toBe(true);
 
     // Omit required field 'foo'
-    collection.insert({ bar: 'test' }, { omit: ['foo'] }, (error, newId2) => {
+    collection.insert({ bar: "test" }, { omit: ["foo"] }, (error, newId2) => {
       expect(!!error).toBe(false);
-      expect(typeof newId2).toBe('string');
+      expect(typeof newId2).toBe("string");
 
       const doc = collection.findOne(newId2);
       expect(doc instanceof Object).toBe(true);
-      expect(doc.foo).toBe(undefined)
-      expect(doc.bar).toBe('test');
+      expect(doc.foo).toBe(undefined);
+      expect(doc.bar).toBe("test");
 
       // Pick only 'foo'
       collection.update(
         { _id: newId2 },
-        { $set: { foo: 'test', bar: 'changed' } },
-        { pick: ['foo'] }, 
-        (error, result) => {  
+        { $set: { foo: "test", bar: "changed" } },
+        { pick: ["foo"] },
+        (error, result) => {
           expect(!!error).toBe(false);
           expect(result).toBe(1);
 
           const doc = collection.findOne(newId2);
           expect(doc instanceof Object).toBe(true);
-          expect(doc.foo).toBe('test');
-          expect(doc.bar).toBe('test');
-
-          done();
+          expect(doc.foo).toBe("test");
+          expect(doc.bar).toBe("test");
         }
       );
     });

--- a/tests/multi.tests.js
+++ b/tests/multi.tests.js
@@ -124,8 +124,8 @@ export default function addMultiTests() {
       expect(combinedSchema.schema('two').type).toEqual(SimpleSchema.oneOf(SimpleSchema.Integer));
 
       // Ensure that we've only attached two deny functions
-      expect(c._validators.insert.deny.length, 2);
-      expect(c._validators.update.deny.length, 2);
+      expect(c._validators.insert.deny.length).toBe(2);
+      expect(c._validators.update.deny.length).toBe(2);
     });
 
     it('inserts doc correctly with selector passed via doc', function (done) {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -3,10 +3,88 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@babel/runtime": {
+    "@babel/code-frame": {
       "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.1.tgz",
-      "integrity": "sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -18,20 +96,108 @@
         }
       }
     },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+    "@jest/types": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
+      "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
       "dev": true,
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
       }
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
+      "integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
+      "integrity": "sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==",
+      "dev": true,
+      "optional": true
+    },
+    "@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -65,6 +231,23 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -75,16 +258,45 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+    "chalk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "clone": {
@@ -92,34 +304,31 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
       "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -130,229 +339,51 @@
         "ms": "^2.1.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+    "diff-sequences": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+      "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
       "dev": true
     },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "once": "^1.4.0"
       }
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
     "expect": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
-      "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.0.1.tgz",
+      "integrity": "sha512-QcCy4nygHeqmbw564YxNbHTJlXh47dVID2BUP52cZFpLU9zHViMFK6h07cC1wf7GYCTIigTdAXhVua8Yl1FkKg==",
       "dev": true,
       "requires": {
-        "define-properties": "~1.1.2",
-        "has": "^1.0.1",
-        "is-equal": "^1.5.1",
-        "is-regex": "^1.0.3",
-        "object-inspect": "^1.1.0",
-        "object-keys": "^1.0.9",
-        "tmatch": "^2.0.1"
-      },
-      "dependencies": {
-        "define-properties": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-          "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-          "dev": true,
-          "requires": {
-            "foreach": "^2.0.5",
-            "object-keys": "^1.0.8"
-          }
-        },
-        "es-abstract": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-          "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.1.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1",
-            "is-callable": "^1.1.3",
-            "is-regex": "^1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-          "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.1",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.1"
-          }
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-          "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-          "dev": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-          "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.0.2"
-          }
-        },
-        "is-arrow-function": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-          "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.0.4"
-          }
-        },
-        "is-boolean-object": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-          "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-          "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-          "dev": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-          "dev": true
-        },
-        "is-equal": {
-          "version": "1.5.5",
-          "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-          "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1",
-            "is-arrow-function": "^2.0.3",
-            "is-boolean-object": "^1.0.0",
-            "is-callable": "^1.1.3",
-            "is-date-object": "^1.0.1",
-            "is-generator-function": "^1.0.6",
-            "is-number-object": "^1.0.3",
-            "is-regex": "^1.0.3",
-            "is-string": "^1.0.4",
-            "is-symbol": "^1.0.1",
-            "object.entries": "^1.0.4"
-          }
-        },
-        "is-generator-function": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
-          "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q=",
-          "dev": true
-        },
-        "is-number-object": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-          "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-string": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-          "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-          "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.0.tgz",
-          "integrity": "sha512-6QW38aBzieGzJqBaq0VBCgVMuluSYAHMH0xR1CMGfVU3mWLimWhkP97NGBLpJZXYDswaY+Qbo7ExFMTE0w/6zQ==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-          "dev": true
-        },
-        "object.entries": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-          "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.6.1",
-            "function-bind": "^1.1.0",
-            "has": "^1.0.1"
-          }
-        },
-        "tmatch": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-          "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
-          "dev": true
-        }
+        "@jest/types": "^26.0.1",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^26.0.0",
+        "jest-matcher-utils": "^26.0.1",
+        "jest-message-util": "^26.0.1",
+        "jest-regex-util": "^26.0.0"
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+      "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "fd-slicer": {
@@ -364,11 +395,35 @@
         "pend": "~1.2.0"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -384,26 +439,33 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
     "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "agent-base": "5",
+        "debug": "4"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -421,10 +483,68 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "jest-diff": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.0.1.tgz",
+      "integrity": "sha512-odTcHyl5X+U+QsczJmOjWw5tPvww+y9Yim5xzqxVl/R1j4z71+fHW4g8qu1ugMmKdFdxw+AtQgs5mupPnzcIBQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.0.0",
+        "jest-get-type": "^26.0.0",
+        "pretty-format": "^26.0.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+      "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.0.1.tgz",
+      "integrity": "sha512-PUMlsLth0Azen8Q2WFTwnSkGh2JZ8FYuwijC8NR47vXKpsrKmA1wWvgcj1CquuVfcYiDEdj985u5Wmg7COEARw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.0.1",
+        "jest-get-type": "^26.0.0",
+        "pretty-format": "^26.0.1"
+      }
+    },
+    "jest-message-util": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.0.1.tgz",
+      "integrity": "sha512-CbK8uQREZ8umUfo8+zgIfEt+W7HAHjQCoRaNs4WxKGhAYBGwEyvxuK81FXa7VeB9pwDEXeeKOB2qcsNVCAvB7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/types": "^26.0.1",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.2"
+      }
+    },
+    "jest-regex-util": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+      "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -1018,10 +1138,20 @@
         }
       }
     },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
+    },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
       "dev": true
     },
     "minimatch": {
@@ -1033,20 +1163,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "mongo-object": {
       "version": "0.1.4",
@@ -1080,11 +1201,23 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
+      "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      }
     },
     "progress": {
       "version": "2.0.3",
@@ -1093,40 +1226,54 @@
       "dev": true
     },
     "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "puppeteer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
-      "integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.3.0.tgz",
+      "integrity": "sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^3.0.0",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -1135,18 +1282,18 @@
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
     "simpl-schema": {
@@ -1159,20 +1306,96 @@
         "mongo-object": "^0.1.4"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+      "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1187,13 +1410,10 @@
       "dev": true
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -75,6 +75,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -321,15 +327,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -350,9 +356,9 @@
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -1028,18 +1034,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mongo-object": {
@@ -1109,9 +1115,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1190,12 +1196,13 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,13 +7,13 @@
     "test:watch:browser": "METEOR_PACKAGE_DIRS=../package TEST_WATCH=1 meteor test --driver-package meteortesting:mocha --raw-logs"
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.1",
+    "@babel/runtime": "^7.10.2",
     "babel-polyfill": "6.26.0",
     "meteor-node-stubs": "1.0.0",
     "simpl-schema": "1.7.3"
   },
   "devDependencies": {
-    "expect": "^1.20.2",
-    "puppeteer": "^2.0.0"
+    "expect": "^26.0.1",
+    "puppeteer": "^3.3.0"
   }
 }


### PR DESCRIPTION
- Did `npm audit` and fixed a sub-package
- Updated `@babel/runtime`, `expect` and `puppeteer`
- Fixed a test related to expect update
- Fixed `pick or omit schema fields when options are provided`
- Renamed `upsert vanilla nested objects which doesn't logical operators value` into `upsert with schema can handle nested objects correctly` and fixed
- Applied formatting to `collection2.tests.js`