### PR TITLE
Force dependencies to the newest version

### DIFF
--- a/package/collection2/package.js
+++ b/package/collection2/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: "aldeed:collection2",
   summary: "Automatic validation of Meteor Mongo insert and update operations on the client and server",
-  version: "3.2.2",
+  version: "3.3.0",
   documentation: "../../README.md",
   git: "https://github.com/aldeed/meteor-collection2.git"
 });
@@ -20,9 +20,9 @@ Package.onUse(function(api) {
   api.imply('mongo');
   api.use('minimongo@1.6.0');
   api.use('ejson@1.1.1');
-  api.use('raix:eventemitter@0.1.3 || 1.0.0');
+  api.use('raix:eventemitter@1.0.0');
   api.use('ecmascript@0.14.3');
-  api.use('tmeasday:check-npm-versions@0.3.2 || 1.0.1');
+  api.use('tmeasday:check-npm-versions@1.0.1');
 
   // Allow us to detect 'insecure'.
   api.use('insecure@1.0.7', {weak: true});


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [What](#what)
- [Why](#why)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What
Updates dependencies to only allow latest version.

<!-- Why are these changes necessary? -->
## Why
Force usage of the newest version to reduce bundle among other benefits. 

<!-- Anything else beside this PR that needs to happen? -->
Another question is if we should bump just a feature version or major version.