### PR TITLE
Add compatibility with Meteor 2.6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [What](#what)
-- [Why](#why)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 <!--
 Thank you for your interest in the project! We appreciate your submission!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [3.5.1](#351)
 - [3.5.0](#350)
 - [3.4.1](#341)
 - [3.4.0](#340)
@@ -76,6 +77,10 @@
 - [0.1.6](#016)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 3.5.1
+
+Add compatibility with Meteor 2.6
 
 ## 3.5.0
 

--- a/package/collection2/package.js
+++ b/package/collection2/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: "aldeed:collection2",
   summary: "Automatic validation of Meteor Mongo insert and update operations on the client and server",
-  version: "3.5.0",
+  version: "3.5.1",
   documentation: "../../README.md",
   git: "https://github.com/aldeed/meteor-collection2.git"
 });
@@ -15,7 +15,7 @@ Npm.depends({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom(['1.12.1', '2.3']);
+  api.versionsFrom(['1.12.1', '2.3', '2.6']);
   api.use('mongo');
   api.imply('mongo');
   api.use('minimongo');


### PR DESCRIPTION
Add Meteor 2.6 to versionsFrom to account for mongo update.